### PR TITLE
Add end to end integration test python client service

### DIFF
--- a/crossdock/server/endtoend.py
+++ b/crossdock/server/endtoend.py
@@ -1,0 +1,71 @@
+import tornado.web
+import json
+
+from jaeger_client.local_agent_net import LocalAgentSender
+from jaeger_client.config import (
+    Config,
+    DEFAULT_SAMPLING_PORT,
+    DEFAULT_REPORTING_PORT,
+)
+from jaeger_client.sampler import RemoteControlledSampler
+from jaeger_client.reporter import Reporter
+from jaeger_client.tracer import Tracer
+
+config = {
+    'service_name': 'crossdock-python',
+    'enabled': True,
+    'sampler': {
+        'type': 'probabilistic',
+        'param': 1,
+    },
+    'reporter_flush_interval': 1,
+    'sampling_refresh_interval': 5,
+}
+
+class EndToEndHandler(object):
+
+    def __init__(self):
+        cfg = Config(config)
+        init_sampler = cfg.sampler
+        channel = self.local_agent_sender
+
+        sampler = RemoteControlledSampler(
+            channel=channel,
+            service_name=cfg.service_name,
+            sampling_refresh_interval=cfg.sampling_refresh_interval,
+            init_sampler=init_sampler)
+
+        reporter = Reporter(
+            channel=channel,
+            flush_interval=cfg.reporter_flush_interval)
+
+        self._tracer = Tracer(
+            service_name=cfg.service_name,
+            reporter=reporter,
+            sampler=sampler)
+
+    @property
+    def tracer(self):
+        return self._tracer
+
+    @tracer.setter
+    def tracer(self, tracer):
+        self._tracer = tracer
+
+    @property
+    def local_agent_sender(self):
+        return LocalAgentSender(
+            host='test_driver',
+            sampling_port=DEFAULT_SAMPLING_PORT,
+            reporting_port=DEFAULT_REPORTING_PORT,
+        )
+
+    @tornado.gen.coroutine
+    def generate_traces(self, request, response_writer):
+        req = json.loads(request.body)
+        for _ in range(req.get('count', 0)):
+            span = self.tracer.start_span(req['operation'])
+            for k, v in req.get('tags', {}).iteritems():
+                span.set_tag(k, v)
+            span.finish()
+        response_writer.finish()

--- a/crossdock/server/endtoend.py
+++ b/crossdock/server/endtoend.py
@@ -23,6 +23,21 @@ config = {
 }
 
 class EndToEndHandler(object):
+    """
+    Handler that creates traces from a http request.
+
+    json: {
+        "operation": "operationName",
+        "count": 2,
+        "tags": {
+            "key": "value"
+        }
+    }
+
+    Given the above json payload, the handler will create 2 traces for the "operationName"
+    operation with the tags: {"key":"value"}. These traces are reported to the agent with
+    the hostname "test_driver".
+    """
 
     def __init__(self):
         cfg = Config(config)

--- a/crossdock/server/endtoend.py
+++ b/crossdock/server/endtoend.py
@@ -22,6 +22,7 @@ config = {
     'sampling_refresh_interval': 5,
 }
 
+
 class EndToEndHandler(object):
     """
     Handler that creates traces from a http request.

--- a/crossdock/server/server.py
+++ b/crossdock/server/server.py
@@ -87,7 +87,8 @@ def make_app(server, endtoend_handler):
             (r'/', MainHandler),
             (r'/start_trace', MainHandler, (dict(server=server, method=Server.start_trace))),
             (r'/join_trace', MainHandler, (dict(server=server, method=Server.join_trace))),
-            (r'/create_traces', MainHandler, (dict(server=endtoend_handler, method=EndToEndHandler.generate_traces))),
+            (r'/create_traces', MainHandler, (dict(server=endtoend_handler,
+                                                   method=EndToEndHandler.generate_traces))),
         ], debug=True, autoreload=False)
 
 

--- a/crossdock/server/server.py
+++ b/crossdock/server/server.py
@@ -9,6 +9,7 @@ from jaeger_client import Tracer, ConstSampler
 from jaeger_client.reporter import NullReporter
 import crossdock.server.constants as constants
 import crossdock.server.serializer as serializer
+from crossdock.server.endtoend import EndToEndHandler
 from opentracing_instrumentation import http_client, http_server, get_current_span, request_context
 from opentracing_instrumentation.client_hooks import tornado_http
 import opentracing.ext.tags as ext_tags
@@ -48,7 +49,8 @@ def serve():
     logging.getLogger().setLevel(logging.DEBUG)
     logging.info('Python Tornado Crossdock Server Running ...')
     server = Server(DefaultServerPortTChannel)
-    app = make_app(server)
+    endtoend_handler = EndToEndHandler()
+    app = make_app(server, endtoend_handler)
     app.listen(DefaultClientPortHTTP)
     app.listen(DefaultServerPortHTTP)
     server.tchannel.listen()
@@ -79,12 +81,13 @@ class MainHandler(tornado.web.RequestHandler):
         pass
 
 
-def make_app(server):
+def make_app(server, endtoend_handler):
     return tornado.web.Application(
         [
             (r'/', MainHandler),
             (r'/start_trace', MainHandler, (dict(server=server, method=Server.start_trace))),
             (r'/join_trace', MainHandler, (dict(server=server, method=Server.join_trace))),
+            (r'/create_traces', MainHandler, (dict(server=endtoend_handler, method=EndToEndHandler.generate_traces))),
         ], debug=True, autoreload=False)
 
 


### PR DESCRIPTION
The client service simply creates traces given a http request. Currently, we only support running this integration test from the internal jaeger repo but will be available to run locally in the future  