### PR TITLE
Client enhancements

### DIFF
--- a/jaeger_client/reporter.py
+++ b/jaeger_client/reporter.py
@@ -44,6 +44,9 @@ class NullReporter(object):
     def report_span(self, span):
         pass
 
+    def report_spans(self, spans):
+        pass
+
     def close(self):
         fut = Future()
         fut.set_result(True)
@@ -61,6 +64,10 @@ class InMemoryReporter(NullReporter):
         with self.lock:
             self.spans.append(span)
 
+    def report_spans(self, spans):
+        with self.lock:
+            self.spans.append(spans)
+
     def get_spans(self):
         with self.lock:
             return self.spans[:]
@@ -73,6 +80,10 @@ class LoggingReporter(NullReporter):
 
     def report_span(self, span):
         self.logger.info('Reporting span %s', span)
+
+    def report_spans(self, spans):
+        for span in spans:
+            self.logger.info('Reporting span %s', span)
 
 
 class Reporter(NullReporter):
@@ -126,6 +137,10 @@ class Reporter(NullReporter):
             self._report_span_from_ioloop(span)
         else:
             self.io_loop.add_callback(self._report_span_from_ioloop, span)
+
+    def report_spans(self, spans):
+        for span in spans:
+            self.report_span(span)
 
     def _report_span_from_ioloop(self, span):
         try:
@@ -229,6 +244,10 @@ class CompositeReporter(NullReporter):
     def report_span(self, span):
         for reporter in self.reporters:
             reporter.report_span(span)
+
+    def report_spans(self, spans):
+        for reporter in self.reporters:
+            reporter.report_spans(spans)
 
     def close(self):
         from threading import Lock

--- a/jaeger_client/span.py
+++ b/jaeger_client/span.py
@@ -68,7 +68,7 @@ class Span(opentracing.Span):
             self.operation_name = operation_name
         return self
 
-    def finish(self, finish_time=None):
+    def finish(self, finish_time=None, defer_report=False):
         """Indicate that the work represented by this span has been completed
         or terminated, and is ready to be sent to the Reporter.
 
@@ -82,7 +82,8 @@ class Span(opentracing.Span):
             return
 
         self.end_time = finish_time or time.time()  # no locking
-        self.tracer.report_span(self)
+        if not defer_report:
+            self.tracer.report_span(self)
 
     def set_tag(self, key, value):
         """

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -46,7 +46,7 @@ class Tracer(opentracing.Tracer):
                  trace_id_header=constants.TRACE_ID_HEADER,
                  baggage_header_prefix=constants.BAGGAGE_HEADER_PREFIX,
                  debug_id_header=constants.DEBUG_ID_HEADER_KEY,
-                 one_span_per_rpc=True):
+                 one_span_per_rpc=True, extra_codecs=None):
         self.service_name = service_name
         self.reporter = reporter
         self.sampler = sampler
@@ -70,6 +70,8 @@ class Tracer(opentracing.Tracer):
             Format.BINARY: BinaryCodec(),
             ZipkinSpanFormat: ZipkinCodec(),
         }
+        if extra_codecs:
+            self.codecs.update(extra_codecs)
         self.tags = {
             constants.JAEGER_VERSION_TAG_KEY: constants.JAEGER_CLIENT_VERSION,
         }

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -45,7 +45,8 @@ class Tracer(opentracing.Tracer):
     def __init__(self, service_name, reporter, sampler, metrics=None,
                  trace_id_header=constants.TRACE_ID_HEADER,
                  baggage_header_prefix=constants.BAGGAGE_HEADER_PREFIX,
-                 debug_id_header=constants.DEBUG_ID_HEADER_KEY):
+                 debug_id_header=constants.DEBUG_ID_HEADER_KEY,
+                 one_span_per_rpc=True):
         self.service_name = service_name
         self.reporter = reporter
         self.sampler = sampler
@@ -72,6 +73,7 @@ class Tracer(opentracing.Tracer):
         self.tags = {
             constants.JAEGER_VERSION_TAG_KEY: constants.JAEGER_CLIENT_VERSION,
         }
+        self.one_span_per_rpc = one_span_per_rpc
         # noinspection PyBroadException
         try:
             hostname = socket.gethostname()
@@ -136,7 +138,7 @@ class Tracer(opentracing.Tracer):
                 tags[self.debug_id_header] = parent.debug_id
         else:
             trace_id = parent.trace_id
-            if rpc_server:
+            if rpc_server and self.one_span_per_rpc:
                 # Zipkin-style one-span-per-RPC
                 span_id = parent.span_id
                 parent_id = parent.parent_id

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -212,5 +212,8 @@ class Tracer(opentracing.Tracer):
     def report_span(self, span):
         self.reporter.report_span(span)
 
+    def report_spans(self, spans):
+        self.reporter.report_spans(spans)
+
     def random_id(self):
         return self.random.getrandbits(constants.MAX_ID_BITS)


### PR DESCRIPTION
This PR add three things:
* The ability to override the codecs used by the tracer on initialization.
* The ability to override the default one-span-per-rpc behaviour on server-side spans.
  This is quite useful for visualizing the server-side spans on a call as nested spans.
* An interface and a mechanism that allows an external entity to accumulate and batch reporting spans for performance reasons.