### PR TITLE
Optionally override one-span-per-rpc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ History
 3.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow overriding one-span-per-rpc behavior
 
 
 3.3.1 (2016-10-14)

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -45,7 +45,8 @@ class Tracer(opentracing.Tracer):
     def __init__(self, service_name, reporter, sampler, metrics=None,
                  trace_id_header=constants.TRACE_ID_HEADER,
                  baggage_header_prefix=constants.BAGGAGE_HEADER_PREFIX,
-                 debug_id_header=constants.DEBUG_ID_HEADER_KEY):
+                 debug_id_header=constants.DEBUG_ID_HEADER_KEY,
+                 one_span_per_rpc=True):
         self.service_name = service_name
         self.reporter = reporter
         self.sampler = sampler
@@ -72,6 +73,7 @@ class Tracer(opentracing.Tracer):
         self.tags = {
             constants.JAEGER_VERSION_TAG_KEY: constants.JAEGER_CLIENT_VERSION,
         }
+        self.one_span_per_rpc = one_span_per_rpc
         # noinspection PyBroadException
         try:
             hostname = socket.gethostname()
@@ -136,7 +138,7 @@ class Tracer(opentracing.Tracer):
                 tags[self.debug_id_header] = parent.debug_id
         else:
             trace_id = parent.trace_id
-            if rpc_server:
+            if rpc_server and self.one_span_per_rpc:
                 # Zipkin-style one-span-per-RPC
                 span_id = parent.span_id
                 parent_id = parent.parent_id


### PR DESCRIPTION
Add option to override default one-span-per-rpc behaviour. This is
useful to visualize RPC calls as nested spans.