### PR TITLE
Skip upload to docker hub on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,5 @@ after_success:
   - $DOCKER build -f crossdock/Dockerfile -t $REPO:$COMMIT .
   - $DOCKER tag $REPO:$COMMIT $REPO:$TAG
   - $DOCKER tag $REPO:$COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER
-  - $DOCKERpush $REPO
+  - $DOCKER push $REPO
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,10 @@ after_success:
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
   - export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, REPO=$REPO, PR=$PR, BRANCH=$BRANCH, TAG=$TAG"
-  - docker login -u $DOCKER_USER -p $DOCKER_PASS
-  - docker build -f crossdock/Dockerfile -t $REPO:$COMMIT .
-  - docker tag $REPO:$COMMIT $REPO:$TAG
-  - docker tag $REPO:$COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER
-  - docker push $REPO
+  - export DOCKER=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo docker; else echo 'skip docker upload for PR; true'; fi)
+  - $DOCKER login -u $DOCKER_USER -p $DOCKER_PASS
+  - $DOCKER build -f crossdock/Dockerfile -t $REPO:$COMMIT .
+  - $DOCKER tag $REPO:$COMMIT $REPO:$TAG
+  - $DOCKER tag $REPO:$COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER
+  - $DOCKERpush $REPO
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ services:
 
 env:
   global:
-    - DOCKER_VERSION=1.10.1-0~trusty
     - DOCKER_COMPOSE_VERSION=1.6.0
     - COMMIT=${TRAVIS_COMMIT::8}
     # DOCKER_USER

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,8 @@ after_success:
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
   - export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, REPO=$REPO, PR=$PR, BRANCH=$BRANCH, TAG=$TAG"
-  - export DOCKER=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo docker; else echo 'skip docker upload for PR; true'; fi)
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo 'upload to Docker Hub'; else echo 'skip docker upload for PR'; fi
+  - export DOCKER=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo docker; else echo true; fi)
   - $DOCKER login -u $DOCKER_USER -p $DOCKER_PASS
   - $DOCKER build -f crossdock/Dockerfile -t $REPO:$COMMIT .
   - $DOCKER tag $REPO:$COMMIT $REPO:$TAG


### PR DESCRIPTION
To reduce noise for docker hub, but also to allow PRs from forks to succeed, as otherwise they break since travis cannot decrypt the secrets for forks.