### PR TITLE
Add option to provide extra codecs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ History
 ------------------
 
 - Allow overriding one-span-per-rpc behavior
+- Allow overriding codecs in tracer initialization
 
 
 3.3.1 (2016-10-14)

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -46,7 +46,7 @@ class Tracer(opentracing.Tracer):
                  trace_id_header=constants.TRACE_ID_HEADER,
                  baggage_header_prefix=constants.BAGGAGE_HEADER_PREFIX,
                  debug_id_header=constants.DEBUG_ID_HEADER_KEY,
-                 one_span_per_rpc=True):
+                 one_span_per_rpc=True, extra_codecs=None):
         self.service_name = service_name
         self.reporter = reporter
         self.sampler = sampler
@@ -70,6 +70,8 @@ class Tracer(opentracing.Tracer):
             Format.BINARY: BinaryCodec(),
             ZipkinSpanFormat: ZipkinCodec(),
         }
+        if extra_codecs:
+            self.codecs.update(extra_codecs)
         self.tags = {
             constants.JAEGER_VERSION_TAG_KEY: constants.JAEGER_CLIENT_VERSION,
         }

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -238,3 +238,20 @@ def test_tracer_tags_on_root_span(span_type, expected_tags):
             )
             assert found_tag.value == value, \
                 'test (%s): expecting tag %s=%s' % (span_type, key, value)
+
+
+def test_tracer_override_codecs():
+    reporter = mock.MagicMock()
+    sampler = ConstSampler(True)
+    codecs = {
+        'extra_codec': "codec_placeholder",
+        Format.BINARY: "overridden_binary_codec"
+
+    }
+    with mock.patch('socket.gethostname', return_value='dream-host.com'):
+        tracer = Tracer(service_name='x', reporter=reporter, sampler=sampler,
+                        extra_codecs=codecs)
+        assert tracer.codecs['extra_codec'] == "codec_placeholder",\
+                "Extra codec not found"
+        assert tracer.codecs[Format.BINARY] == "overridden_binary_codec",\
+                "Binary format codec not overridden"


### PR DESCRIPTION
Add options to provide extra codecs to the tracer. This allows extending
or overriding the tracer's codec during initialization.