### PR TITLE
Refactor remote sampler update logic

### DIFF
--- a/jaeger_client/sampler.py
+++ b/jaeger_client/sampler.py
@@ -153,6 +153,9 @@ class RateLimitingSampler(Sampler):
                 SAMPLER_PARAM_TAG_KEY: max_traces_per_second,
             }
         )
+        self._init_rate_limiter(max_traces_per_second)
+
+    def _init_rate_limiter(self, max_traces_per_second):
         assert max_traces_per_second >= 0, \
             'max_traces_per_second must not be negative'
         self.credits_per_second = max_traces_per_second
@@ -191,6 +194,13 @@ class RateLimitingSampler(Sampler):
         d1['balance'] = d2['balance']
         d1['last_tick'] = d2['last_tick']
         return d1 == d2
+
+    def update(self, max_traces_per_second):
+        # (NB) This function should only be called while holding a Write lock.
+        if self.credits_per_second == max_traces_per_second:
+            return
+        # only create a new rate limiter when the credits_per_second is changed
+        self._init_rate_limiter(max_traces_per_second)
 
     def __str__(self):
         return 'RateLimitingSampler(%s)' % self.credits_per_second
@@ -243,9 +253,8 @@ class GuaranteedThroughputProbabilisticSampler(Sampler):
                 SAMPLER_TYPE_TAG_KEY: SAMPLER_TYPE_LOWER_BOUND,
                 SAMPLER_PARAM_TAG_KEY: rate,
             }
-        if self.lower_bound != lower_bound:
-            self.lower_bound_sampler = RateLimitingSampler(lower_bound)
-            self.lower_bound = lower_bound
+        self.lower_bound_sampler.update(lower_bound)
+        self.lower_bound = lower_bound
 
     def __str__(self):
         return 'GuaranteedThroughputProbabilisticSampler(%s, %s, %s)' \
@@ -464,7 +473,10 @@ class RemoteControlledSampler(Sampler):
         elif s_type == SamplingManager.SamplingStrategyType.RATE_LIMITING:
             mtps = response[RATE_LIMITING_SAMPLING_STR][MAX_TRACES_PER_SECOND_STR]
             if 0 <= mtps < 500:
-                self.sampler = RateLimitingSampler(max_traces_per_second=mtps)
+                if isinstance(self.sampler, RateLimitingSampler):
+                    self.sampler.update(max_traces_per_second=mtps)
+                else:
+                    self.sampler = RateLimitingSampler(max_traces_per_second=mtps)
             else:
                 raise ValueError(
                     'Rate limiting parameter not in [0, 500] range: %s' % mtps)

--- a/jaeger_client/sampler.py
+++ b/jaeger_client/sampler.py
@@ -421,8 +421,7 @@ class RemoteControlledSampler(Sampler):
 
         response = future.result()
         try:
-            sampler, strategies = \
-                self._parse_sampling_strategy(self.sampler, response.body)
+            sampling_strategies_response = json.loads(response.body)
         except Exception as e:
             self.error_reporter.error(
                 Metrics.SAMPLER_ERRORS, 1,
@@ -430,13 +429,47 @@ class RemoteControlledSampler(Sampler):
                 'from jaeger-agent: %s [%s]', e, response.body)
             return
 
+        self._update_sampler(sampling_strategies_response)
+        self.logger.debug('Tracing sampler set to %s', self.sampler)
+
+    def _update_sampler(self, response):
         with self.lock:
-            if isinstance(sampler, AdaptiveSampler):
-                sampler.update(strategies)
-            elif self.sampler == sampler:
-                return
-            self.sampler = sampler
-        self.logger.debug('Tracing sampler set to %s', sampler)
+            if response.get(OPERATION_SAMPLING_STR):
+                self._update_adaptive_sampler(response.get(OPERATION_SAMPLING_STR))
+            else:
+                try:
+                    self._update_rate_limiting_or_probabilistic_sampler(response)
+                except Exception as e:
+                    self.error_reporter.error(
+                        Metrics.SAMPLER_ERRORS, 1,
+                        'Fail to update sampler'
+                        'from jaeger-agent: %s [%s]', e, response)
+                    return
+
+    def _update_adaptive_sampler(self, per_operation_strategies):
+        if isinstance(self.sampler, AdaptiveSampler):
+            self.sampler.update(per_operation_strategies)
+        else:
+            self.sampler = AdaptiveSampler(per_operation_strategies, self.max_operations)
+
+    def _update_rate_limiting_or_probabilistic_sampler(self, response):
+        s_type = response[STRATEGY_TYPE_STR]
+        if s_type == SamplingManager.SamplingStrategyType.PROBABILISTIC:
+            sampling_rate = response[PROBABILISTIC_SAMPLING_STR][SAMPLING_RATE_STR]
+            if 0 <= sampling_rate <= 1.0:
+                self.sampler = ProbabilisticSampler(rate=sampling_rate)
+            else:
+                raise ValueError(
+                    'Probabilistic sampling rate not in [0, 1] range: %s' % sampling_rate)
+        elif s_type == SamplingManager.SamplingStrategyType.RATE_LIMITING:
+            mtps = response[RATE_LIMITING_SAMPLING_STR][MAX_TRACES_PER_SECOND_STR]
+            if 0 <= mtps < 500:
+                self.sampler = RateLimitingSampler(max_traces_per_second=mtps)
+            else:
+                raise ValueError(
+                    'Rate limiting parameter not in [0, 500] range: %s' % mtps)
+        else:
+            raise ValueError('Unsupported sampling strategy type: %s' % s_type)
 
     def _poll_sampling_manager(self):
         self.logger.debug('Requesting tracing sampler refresh')
@@ -449,28 +482,3 @@ class RemoteControlledSampler(Sampler):
             self.running = False
             if self.periodic is not None:
                 self.periodic.stop()
-
-    def _parse_sampling_strategy(self, sampler, body):
-        response = json.loads(body)
-        s_type = response[STRATEGY_TYPE_STR]
-        operation_strategies = response.get(OPERATION_SAMPLING_STR)
-        if operation_strategies:
-            if isinstance(sampler, AdaptiveSampler):
-                return sampler, operation_strategies
-            return AdaptiveSampler(operation_strategies, self.max_operations), operation_strategies
-        if s_type == SamplingManager.SamplingStrategyType.PROBABILISTIC:
-            sampling_rate = response[PROBABILISTIC_SAMPLING_STR][SAMPLING_RATE_STR]
-            if 0 <= sampling_rate <= 1.0:
-                return ProbabilisticSampler(rate=sampling_rate), None
-            else:
-                raise ValueError(
-                    'Probabilistic sampling rate not in [0, 1] range: %s' % sampling_rate)
-        elif s_type == SamplingManager.SamplingStrategyType.RATE_LIMITING:
-            mtps = response[RATE_LIMITING_SAMPLING_STR][MAX_TRACES_PER_SECOND_STR]
-            if 0 <= mtps < 500:
-                return RateLimitingSampler(max_traces_per_second=mtps), None
-            else:
-                raise ValueError(
-                    'Rate limiting parameter not in [0, 500] range: %s' % mtps)
-        else:
-            raise ValueError('Unsupported sampling strategy type: %s' % s_type)

--- a/tests/test_local_agent_net.py
+++ b/tests/test_local_agent_net.py
@@ -1,0 +1,40 @@
+import pytest
+import tornado.web
+from urlparse import urlparse
+from jaeger_client.local_agent_net import LocalAgentSender
+from jaeger_client.config import DEFAULT_REPORTING_PORT
+
+test_strategy = """
+    {
+        "strategyType":0,
+        "probabilisticSampling":
+        {
+            "samplingRate":0.002
+        }
+    }
+    """
+
+
+class AgentHandler(tornado.web.RequestHandler):
+    def get(self):
+        self.write(test_strategy)
+
+application = tornado.web.Application([
+    (r"/sampling", AgentHandler),
+])
+
+@pytest.fixture
+def app():
+    return application
+
+
+@pytest.mark.gen_test
+def test_request_sampling_strategy(http_client, base_url):
+    o = urlparse(base_url)
+    sender = LocalAgentSender(
+        host='localhost',
+        sampling_port=o.port,
+        reporting_port=DEFAULT_REPORTING_PORT
+    )
+    response = yield sender.request_sampling_strategy(service_name='svc', timeout=15)
+    assert response.body == test_strategy

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -333,7 +333,7 @@ def test_sampling_request_callback():
 
     # noinspection PyProtectedMember
     sampler._sampling_request_callback(return_value)
-    assert prev_sampler == sampler.sampler, "strategy hasn't changed so sampler should not change"
+    assert prev_sampler is sampler.sampler, "strategy hasn't changed so sampler should not change"
 
     adaptive_sampling_strategy = """
     {
@@ -363,13 +363,13 @@ def test_sampling_request_callback():
 
     # noinspection PyProtectedMember
     sampler._sampling_request_callback(return_value)
-    assert prev_sampler == sampler.sampler, "strategy hasn't changed so sampler should not change"
+    assert prev_sampler is sampler.sampler, "strategy hasn't changed so sampler should not change"
 
     return_value.exception = lambda *args: True
     # noinspection PyProtectedMember
     sampler._sampling_request_callback(return_value)
     assert error_reporter.error.call_count == 1
-    assert prev_sampler == sampler.sampler,'error fetching strategy should not update the sampler'
+    assert prev_sampler is sampler.sampler, 'error fetching strategy should not update the sampler'
 
     return_value.exception = lambda *args: False
     return_value.result = lambda *args: type('obj', (object,), {'body': 'bad_json'})()
@@ -377,7 +377,7 @@ def test_sampling_request_callback():
     # noinspection PyProtectedMember
     sampler._sampling_request_callback(return_value)
     assert error_reporter.error.call_count == 2
-    assert prev_sampler == sampler.sampler, 'error updating sampler should not update the sampler'
+    assert prev_sampler is sampler.sampler, 'error updating sampler should not update the sampler'
 
     return_value.result = lambda *args: \
         type('obj', (object,), {'body': probabilistic_strategy})()
@@ -404,7 +404,7 @@ def test_update_sampler():
 
     # noinspection PyProtectedMember
     remote_sampler._update_sampler({"strategyType":0,"probabilisticSampling":{"samplingRate":400}})
-    assert prev_sampler == remote_sampler.sampler, 'sampler should remain the same'
+    assert prev_sampler is remote_sampler.sampler, 'sampler should remain the same'
     assert error_reporter.error.call_count == 1
 
     # noinspection PyProtectedMember
@@ -414,11 +414,11 @@ def test_update_sampler():
 
     # noinspection PyProtectedMember
     remote_sampler._update_sampler({"strategyType":1,"rateLimitingSampling":{"maxTracesPerSecond":10}})
-    assert prev_sampler == remote_sampler.sampler, 'sampler should remain the same with the same strategy'
+    assert prev_sampler is remote_sampler.sampler, 'sampler should remain the same with the same strategy'
 
     # noinspection PyProtectedMember
     remote_sampler._update_sampler({"strategyType":1,"rateLimitingSampling":{"maxTracesPerSecond":-10}})
-    assert prev_sampler == remote_sampler.sampler, 'sampler should remain the same if strategy is invalid'
+    assert prev_sampler is remote_sampler.sampler, 'sampler should remain the same if strategy is invalid'
     assert error_reporter.error.call_count == 2
 
     # noinspection PyProtectedMember

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -299,6 +299,7 @@ def test_remotely_controlled_sampler():
     sampler.close()
 
 
+# noinspection PyProtectedMember
 def test_sampling_request_callback():
     channel = mock.MagicMock()
     channel.io_loop = mock.MagicMock()
@@ -326,12 +327,10 @@ def test_sampling_request_callback():
 
     return_value.result = lambda *args: \
         type('obj', (object,), {'body': probabilistic_strategy})()
-    # noinspection PyProtectedMember
     sampler._sampling_request_callback(return_value)
     assert '%s' % sampler.sampler == 'ProbabilisticSampler(0.002)', 'sampler should have changed to probabilistic'
     prev_sampler = sampler.sampler
 
-    # noinspection PyProtectedMember
     sampler._sampling_request_callback(return_value)
     assert prev_sampler is sampler.sampler, "strategy hasn't changed so sampler should not change"
 
@@ -356,17 +355,14 @@ def test_sampling_request_callback():
     """
     return_value.result = lambda *args: \
         type('obj', (object,), {'body': adaptive_sampling_strategy})()
-    # noinspection PyProtectedMember
     sampler._sampling_request_callback(return_value)
     assert '%s' % sampler.sampler == 'AdaptiveSampler(0.001, 2, 10)', 'sampler should have changed to adaptive'
     prev_sampler = sampler.sampler
 
-    # noinspection PyProtectedMember
     sampler._sampling_request_callback(return_value)
     assert prev_sampler is sampler.sampler, "strategy hasn't changed so sampler should not change"
 
     return_value.exception = lambda *args: True
-    # noinspection PyProtectedMember
     sampler._sampling_request_callback(return_value)
     assert error_reporter.error.call_count == 1
     assert prev_sampler is sampler.sampler, 'error fetching strategy should not update the sampler'
@@ -374,14 +370,12 @@ def test_sampling_request_callback():
     return_value.exception = lambda *args: False
     return_value.result = lambda *args: type('obj', (object,), {'body': 'bad_json'})()
 
-    # noinspection PyProtectedMember
     sampler._sampling_request_callback(return_value)
     assert error_reporter.error.call_count == 2
     assert prev_sampler is sampler.sampler, 'error updating sampler should not update the sampler'
 
     return_value.result = lambda *args: \
         type('obj', (object,), {'body': probabilistic_strategy})()
-    # noinspection PyProtectedMember
     sampler._sampling_request_callback(return_value)
     assert '%s' % sampler.sampler == 'ProbabilisticSampler(0.002)', 'updating sampler from adaptive to probabilistic should work'
 
@@ -489,6 +483,7 @@ def test_update_sampler(response, init_sampler, expected_sampler, err_count, err
     remote_sampler.close()
 
 
+# noinspection PyProtectedMember
 def test_update_sampler_adaptive_sampler():
     error_reporter = mock.MagicMock()
     error_reporter.error = mock.MagicMock()
@@ -517,7 +512,6 @@ def test_update_sampler_adaptive_sampler():
         }
     }
 
-    # noinspection PyProtectedMember
     remote_sampler._update_sampler(response)
     assert '%s' % remote_sampler.sampler == 'AdaptiveSampler(0.001, 2, 10)'
 
@@ -539,11 +533,9 @@ def test_update_sampler_adaptive_sampler():
         }
     }
 
-    # noinspection PyProtectedMember
     remote_sampler._update_sampler(new_response)
     assert '%s' % remote_sampler.sampler == 'AdaptiveSampler(0.51, 3, 10)'
 
-    # noinspection PyProtectedMember
     remote_sampler._update_sampler({"strategyType":0,"probabilisticSampling":{"samplingRate":0.004}})
     assert '%s' % remote_sampler.sampler == 'ProbabilisticSampler(0.004)', \
         'should not fail going from adaptive sampler to probabilistic sampler'


### PR DESCRIPTION
Existing logic could run into a NPE when updating the remote sampler from adaptive sampler to any other type. Refactored the logic to make it easier to reason about how the update is happening (just copied the Java implementation).