### PR TITLE
Allow specifying agent host in config

### DIFF
--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -212,7 +212,7 @@ class Config(object):
         # noinspection PyBroadException
         try:
             return self.local_agent_group()['reporting_host']
-        except KeyError:
+        except:
             return DEFAULT_REPORTING_HOST
 
     @property

--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -50,6 +50,7 @@ from .constants import (
 from .metrics import LegacyMetricsFactory, MetricsFactory, Metrics
 from .utils import get_boolean, ErrorReporter
 
+DEFAULT_REPORTING_HOST = 'localhost'
 DEFAULT_REPORTING_PORT = 5775
 DEFAULT_SAMPLING_PORT = 5778
 LOCAL_AGENT_DEFAULT_ENABLED = True
@@ -207,6 +208,14 @@ class Config(object):
             return DEFAULT_SAMPLING_PORT
 
     @property
+    def local_agent_reporting_host(self):
+        # noinspection PyBroadException
+        try:
+            return self.local_agent_group()['reporting_host']
+        except KeyError:
+            return DEFAULT_REPORTING_HOST
+
+    @property
     def local_agent_reporting_port(self):
         # noinspection PyBroadException
         try:
@@ -295,7 +304,7 @@ class Config(object):
         """
         logger.info('Initializing Jaeger Tracer with UDP reporter')
         return LocalAgentSender(
-            host='localhost',
+            host=self.local_agent_reporting_host,
             sampling_port=self.local_agent_sampling_port,
             reporting_port=self.local_agent_reporting_port,
             io_loop=io_loop


### PR DESCRIPTION
This allows setting the Jaeger agent host to something other than `localhost` in config. This scenario is also noted in #47 and this implementation follows the notes given there.

Fixes #47 