### PR TITLE
Allow to set custom hostname(address) for jaeger agent.

### DIFF
--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -50,6 +50,7 @@ from .constants import (
 from .metrics import LegacyMetricsFactory, MetricsFactory, Metrics
 from .utils import get_boolean, ErrorReporter
 
+DEFAULT_REPORTING_HOST = 'localhost'
 DEFAULT_REPORTING_PORT = 5775
 DEFAULT_SAMPLING_PORT = 5778
 LOCAL_AGENT_DEFAULT_ENABLED = True
@@ -215,6 +216,14 @@ class Config(object):
             return DEFAULT_REPORTING_PORT
 
     @property
+    def local_agent_reporting_host(self):
+        # noinspection PyBroadException
+        try:
+            return self.local_agent_group()['reporting_host']
+        except:
+            return DEFAULT_REPORTING_HOST
+
+    @property
     def max_operations(self):
         return self.config.get('max_operations', None)
 
@@ -295,7 +304,7 @@ class Config(object):
         """
         logger.info('Initializing Jaeger Tracer with UDP reporter')
         return LocalAgentSender(
-            host='localhost',
+            host=self.local_agent_reporting_host,
             sampling_port=self.local_agent_sampling_port,
             reporting_port=self.local_agent_reporting_port,
             io_loop=io_loop

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -73,3 +73,10 @@ class ConfigTests(unittest.TestCase):
         c = Config({'sampler': {'type': 'bad-sampler'}}, service_name='x')
         with self.assertRaises(ValueError):
             c.sampler.is_sampled(0)
+
+    def test_agent_reporting_host(self):
+        c = Config({}, service_name='x')
+        assert c.local_agent_reporting_host == 'localhost'
+
+        c = Config({'local_agent': {'reporting_host': 'jaeger.local'}}, service_name='x')
+        assert c.local_agent_reporting_host == 'jaeger.local'


### PR DESCRIPTION
Note:
This is intended to be used when application using jaeger-client-python is running as a container and needs to communicate with jaeger agent running on same host either natively or inside a container.
Specifying a remote agent address ( different host) won't work reliably.

This is same as PR opened by @bendemaree with added UT for new config test.