### PR TITLE
Futurize for Py3 

### DIFF
--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -137,7 +137,7 @@ def span_context_to_string(trace_id, span_id, parent_id, flags):
     :param parent_id:
     :param flags:
     """
-    parent_id = parent_id or 0L
+    parent_id = parent_id or 0
     return '{:x}:{:x}:{:x}:{:x}'.format(trace_id, span_id, parent_id, flags)
 
 

--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -19,8 +19,11 @@
 # THE SOFTWARE.
 
 from __future__ import absolute_import
-from builtins import object
+
 from future import standard_library
+standard_library.install_aliases()  # noqa
+
+from builtins import object
 from past.builtins import basestring
 
 from opentracing import (
@@ -35,12 +38,7 @@ from .constants import (
 from .span_context import SpanContext
 
 import six
-import urllib.error
 import urllib.parse
-import urllib.request
-
-
-standard_library.install_aliases()
 
 
 class Codec(object):

--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -20,6 +20,8 @@
 
 from __future__ import absolute_import
 
+import six
+
 from future import standard_library
 standard_library.install_aliases()
 from past.builtins import basestring
@@ -68,7 +70,7 @@ class TextCodec(Codec):
             parent_id=span_context.parent_id, flags=span_context.flags)
         baggage = span_context.baggage
         if baggage:
-            for key, value in baggage.items():
+            for key, value in six.iteritems(baggage):
                 if self.url_encoding:
                     encoded_value = urllib.parse.quote(value)
                 else:
@@ -81,7 +83,7 @@ class TextCodec(Codec):
         trace_id, span_id, parent_id, flags = None, None, None, None
         baggage = None
         debug_id = None
-        for key, value in carrier.items():
+        for key, value in six.iteritems(carrier):
             uc_key = key.lower()
             if uc_key == self.trace_id_header:
                 if self.url_encoding:

--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -19,25 +19,28 @@
 # THE SOFTWARE.
 
 from __future__ import absolute_import
-
-import six
-
-from future import standard_library
-standard_library.install_aliases()
-from past.builtins import basestring
 from builtins import object
-import urllib.request, urllib.parse, urllib.error
+from future import standard_library
+from past.builtins import basestring
 
 from opentracing import (
     InvalidCarrierException,
     SpanContextCorruptedException,
 )
 from .constants import (
-    TRACE_ID_HEADER,
     BAGGAGE_HEADER_PREFIX,
     DEBUG_ID_HEADER_KEY,
+    TRACE_ID_HEADER,
 )
 from .span_context import SpanContext
+
+import six
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+standard_library.install_aliases()
 
 
 class Codec(object):

--- a/jaeger_client/codecs.py
+++ b/jaeger_client/codecs.py
@@ -20,7 +20,11 @@
 
 from __future__ import absolute_import
 
-import urllib
+from future import standard_library
+standard_library.install_aliases()
+from past.builtins import basestring
+from builtins import object
+import urllib.request, urllib.parse, urllib.error
 
 from opentracing import (
     InvalidCarrierException,
@@ -64,9 +68,9 @@ class TextCodec(Codec):
             parent_id=span_context.parent_id, flags=span_context.flags)
         baggage = span_context.baggage
         if baggage:
-            for key, value in baggage.iteritems():
+            for key, value in baggage.items():
                 if self.url_encoding:
-                    encoded_value = urllib.quote(value)
+                    encoded_value = urllib.parse.quote(value)
                 else:
                     encoded_value = value
                 carrier['%s%s' % (self.baggage_prefix, key)] = encoded_value
@@ -77,16 +81,16 @@ class TextCodec(Codec):
         trace_id, span_id, parent_id, flags = None, None, None, None
         baggage = None
         debug_id = None
-        for key, value in carrier.iteritems():
+        for key, value in carrier.items():
             uc_key = key.lower()
             if uc_key == self.trace_id_header:
                 if self.url_encoding:
-                    value = urllib.unquote(value)
+                    value = urllib.parse.unquote(value)
                 trace_id, span_id, parent_id, flags = \
                     span_context_from_string(value)
             elif uc_key.startswith(self.baggage_prefix):
                 if self.url_encoding:
-                    value = urllib.unquote(value)
+                    value = urllib.parse.unquote(value)
                 attr_key = key[self.prefix_length:]
                 if baggage is None:
                     baggage = {attr_key.lower(): value}
@@ -94,7 +98,7 @@ class TextCodec(Codec):
                     baggage[attr_key.lower()] = value
             elif uc_key == self.debug_id_header:
                 if self.url_encoding:
-                    value = urllib.unquote(value)
+                    value = urllib.parse.unquote(value)
                 debug_id = value
         if not trace_id and baggage:
             raise SpanContextCorruptedException('baggage without trace ctx')
@@ -162,9 +166,9 @@ def span_context_from_string(value):
         raise SpanContextCorruptedException(
             'malformed trace context "%s"' % value)
     try:
-        trace_id = long(parts[0], 16)
-        span_id = long(parts[1], 16)
-        parent_id = long(parts[2], 16)
+        trace_id = int(parts[0], 16)
+        span_id = int(parts[1], 16)
+        parent_id = int(parts[2], 16)
         flags = int(parts[3], 16)
         if trace_id < 1 or span_id < 1 or parent_id < 0 or flags < 0:
             raise SpanContextCorruptedException(

--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import
 
+from builtins import object
 import logging
 import threading
 

--- a/jaeger_client/constants.py
+++ b/jaeger_client/constants.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 from . import __version__
 
+import six
 
 # Max number of bits to use when generating random ID
 MAX_ID_BITS = 64
@@ -33,10 +34,10 @@ DEFAULT_SAMPLING_INTERVAL = 60
 DEFAULT_FLUSH_INTERVAL = 1
 
 # Name of the HTTP header used to encode trace ID
-TRACE_ID_HEADER = b'uber-trace-id'
+TRACE_ID_HEADER = 'uber-trace-id' if six.PY3 else b'uber-trace-id'
 
 # Prefix for HTTP headers used to record baggage items
-BAGGAGE_HEADER_PREFIX = b'uberctx-'
+BAGGAGE_HEADER_PREFIX = 'uberctx-' if six.PY3 else b'uberctx-'
 
 # The name of HTTP header or a TextMap carrier key which, if found in the
 # carrier, forces the trace to be sampled as "debug" trace. The value of the

--- a/jaeger_client/local_agent_net.py
+++ b/jaeger_client/local_agent_net.py
@@ -19,6 +19,7 @@
 # THE SOFTWARE.
 
 from __future__ import absolute_import
+from builtins import object
 from threadloop import ThreadLoop
 import tornado
 import tornado.httpclient

--- a/jaeger_client/metrics.py
+++ b/jaeger_client/metrics.py
@@ -19,8 +19,12 @@
 # THE SOFTWARE.
 
 from __future__ import absolute_import
+from __future__ import division
 
 
+from builtins import str
+from past.utils import old_div
+from builtins import object
 class MetricsFactory(object):
     """Generates new metrics."""
 
@@ -79,7 +83,7 @@ class LegacyMetricsFactory(MetricsFactory):
 
         def record(value):
             # Convert microseconds to milliseconds for legacy
-            return self._metrics.timing(key, value / 1000.0)
+            return self._metrics.timing(key, old_div(value, 1000.0))
         return record
 
     def create_gauge(self, name, tags=None):
@@ -93,7 +97,7 @@ class LegacyMetricsFactory(MetricsFactory):
         if not tags:
             return name
         key = name
-        for k in sorted(tags.iterkeys()):
+        for k in sorted(tags.keys()):
             key = key + '.' + str(k) + '_' + str(tags[k])
         return key
 

--- a/jaeger_client/metrics.py
+++ b/jaeger_client/metrics.py
@@ -23,8 +23,9 @@ from __future__ import division
 
 
 from builtins import str
-from past.utils import old_div
 from builtins import object
+
+
 class MetricsFactory(object):
     """Generates new metrics."""
 
@@ -83,7 +84,7 @@ class LegacyMetricsFactory(MetricsFactory):
 
         def record(value):
             # Convert microseconds to milliseconds for legacy
-            return self._metrics.timing(key, old_div(value, 1000.0))
+            return self._metrics.timing(key, value / 1000.0)
         return record
 
     def create_gauge(self, name, tags=None):

--- a/jaeger_client/metrics.py
+++ b/jaeger_client/metrics.py
@@ -21,9 +21,10 @@
 from __future__ import absolute_import
 from __future__ import division
 
-
 from builtins import str
 from builtins import object
+
+import six
 
 
 class MetricsFactory(object):
@@ -98,7 +99,7 @@ class LegacyMetricsFactory(MetricsFactory):
         if not tags:
             return name
         key = name
-        for k in sorted(tags.keys()):
+        for k in sorted(six.iterkeys(tags)):
             key = key + '.' + str(k) + '_' + str(tags[k])
         return key
 

--- a/jaeger_client/rate_limiter.py
+++ b/jaeger_client/rate_limiter.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from builtins import object
 import time
 
 

--- a/jaeger_client/reporter.py
+++ b/jaeger_client/reporter.py
@@ -19,6 +19,7 @@
 # THE SOFTWARE.
 
 from __future__ import absolute_import
+from builtins import object
 import logging
 import threading
 
@@ -225,7 +226,7 @@ class Reporter(NullReporter):
         yield self.queue.join()
 
 
-class ReporterMetrics:
+class ReporterMetrics(object):
     def __init__(self, metrics_factory):
         self.reporter_success = \
             metrics_factory.create_counter(name='jaeger.spans', tags={'reported': 'true'})

--- a/jaeger_client/sampler.py
+++ b/jaeger_client/sampler.py
@@ -21,9 +21,10 @@
 from __future__ import absolute_import
 from __future__ import division
 from builtins import object
+import json
 import logging
 import random
-import json
+import six
 
 from threading import Lock
 from tornado.ioloop import PeriodicCallback
@@ -308,7 +309,7 @@ class AdaptiveSampler(Sampler):
                 ProbabilisticSampler(self.default_sampling_probability)
 
     def close(self):
-        for _, sampler in self.samplers.items():
+        for _, sampler in six.iteritems(self.samplers):
             sampler.close()
 
     def __str__(self):

--- a/jaeger_client/sampler.py
+++ b/jaeger_client/sampler.py
@@ -19,6 +19,9 @@
 # THE SOFTWARE.
 
 from __future__ import absolute_import
+from __future__ import division
+from builtins import object
+from past.utils import old_div
 import logging
 import random
 import json
@@ -45,7 +48,7 @@ default_logger = logging.getLogger('jaeger_tracing')
 SAMPLER_TYPE_TAG_KEY = 'sampler.type'
 SAMPLER_PARAM_TAG_KEY = 'sampler.param'
 DEFAULT_SAMPLING_PROBABILITY = 0.001
-DEFAULT_LOWER_BOUND = 1.0 / (10.0 * 60.0)  # sample once every 10 minutes
+DEFAULT_LOWER_BOUND = old_div(1.0, (10.0 * 60.0))  # sample once every 10 minutes
 DEFAULT_MAX_OPERATIONS = 2000
 
 STRATEGIES_STR = 'perOperationStrategies'
@@ -306,7 +309,7 @@ class AdaptiveSampler(Sampler):
                 ProbabilisticSampler(self.default_sampling_probability)
 
     def close(self):
-        for _, sampler in self.samplers.iteritems():
+        for _, sampler in self.samplers.items():
             sampler.close()
 
     def __str__(self):

--- a/jaeger_client/sampler.py
+++ b/jaeger_client/sampler.py
@@ -21,7 +21,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from builtins import object
-from past.utils import old_div
 import logging
 import random
 import json
@@ -48,7 +47,7 @@ default_logger = logging.getLogger('jaeger_tracing')
 SAMPLER_TYPE_TAG_KEY = 'sampler.type'
 SAMPLER_PARAM_TAG_KEY = 'sampler.param'
 DEFAULT_SAMPLING_PROBABILITY = 0.001
-DEFAULT_LOWER_BOUND = old_div(1.0, (10.0 * 60.0))  # sample once every 10 minutes
+DEFAULT_LOWER_BOUND = 1.0 / (10.0 * 60.0)  # sample once every 10 minutes
 DEFAULT_MAX_OPERATIONS = 2000
 
 STRATEGIES_STR = 'perOperationStrategies'

--- a/jaeger_client/span.py
+++ b/jaeger_client/span.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import
 
+from builtins import str
 import json
 import threading
 import time
@@ -54,7 +55,7 @@ class Span(opentracing.Span):
         self.tags = []
         self.logs = []
         if tags:
-            for k, v in tags.iteritems():
+            for k, v in tags.items():
                 self.set_tag(k, v)
 
     def set_operation_name(self, operation_name):

--- a/jaeger_client/span.py
+++ b/jaeger_client/span.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 
 from builtins import str
 import json
+import six
 import threading
 import time
 
@@ -55,7 +56,7 @@ class Span(opentracing.Span):
         self.tags = []
         self.logs = []
         if tags:
-            for k, v in tags.items():
+            for k, v in six.iteritems(tags):
                 self.set_tag(k, v)
 
     def set_operation_name(self, operation_name):

--- a/jaeger_client/thrift.py
+++ b/jaeger_client/thrift.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from past.builtins import basestring
 import socket
 import struct
 
@@ -117,7 +118,7 @@ def timestamp_micros(ts):
     :param ts:
     :return:
     """
-    return long(ts * 1000000)
+    return int(ts * 1000000)
 
 
 def make_zipkin_spans(spans):

--- a/jaeger_client/thrift.py
+++ b/jaeger_client/thrift.py
@@ -19,6 +19,7 @@
 # THE SOFTWARE.
 
 from past.builtins import basestring
+import six
 import socket
 import struct
 
@@ -33,6 +34,9 @@ _max_signed_port = (1 << 15) - 1
 _max_unsigned_port = (1 << 16)
 _max_signed_id = (1 << 63) - 1
 _max_unsigned_id = (1 << 64)
+
+if six.PY3:
+    long = int
 
 
 def ipv4_to_int(ipv4):
@@ -118,7 +122,7 @@ def timestamp_micros(ts):
     :param ts:
     :return:
     """
-    return int(ts * 1000000)
+    return long(ts * 1000000)
 
 
 def make_zipkin_spans(spans):

--- a/jaeger_client/thrift.py
+++ b/jaeger_client/thrift.py
@@ -30,8 +30,8 @@ from .thrift_gen.zipkincore.constants import LOCAL_COMPONENT
 
 _max_signed_port = (1 << 15) - 1
 _max_unsigned_port = (1 << 16)
-_max_signed_id = (1L << 63) - 1
-_max_unsigned_id = (1L << 64)
+_max_signed_id = (1 << 63) - 1
+_max_unsigned_id = (1 << 64)
 
 
 def ipv4_to_int(ipv4):

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import
 
+from builtins import object
 import socket
 
 import os
@@ -137,7 +138,7 @@ class Tracer(opentracing.Tracer):
                 if sampled:
                     flags = SAMPLED_FLAG
                     tags = tags or {}
-                    for k, v in sampler_tags.iteritems():
+                    for k, v in sampler_tags.items():
                         tags[k] = v
             else:  # have debug id
                 flags = SAMPLED_FLAG | DEBUG_FLAG
@@ -164,7 +165,7 @@ class Tracer(opentracing.Tracer):
 
         if (rpc_server or not parent_id) and (flags & SAMPLED_FLAG):
             # this is a first-in-process span, and is sampled
-            for k, v in self.tags.iteritems():
+            for k, v in self.tags.items():
                 span.set_tag(k, v)
 
         self._emit_span_metrics(span=span, join=rpc_server)
@@ -225,7 +226,7 @@ class Tracer(opentracing.Tracer):
         return self.random.getrandbits(constants.MAX_ID_BITS)
 
 
-class TracerMetrics:
+class TracerMetrics(object):
     """Tracer specific metrics."""
 
     def __init__(self, metrics_factory):

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -23,10 +23,11 @@ from __future__ import absolute_import
 from builtins import object
 import socket
 
-import os
-import time
 import logging
+import os
 import random
+import time
+import six
 import opentracing
 from opentracing import Format, UnsupportedFormatException
 from opentracing.ext import tags as ext_tags
@@ -138,7 +139,7 @@ class Tracer(opentracing.Tracer):
                 if sampled:
                     flags = SAMPLED_FLAG
                     tags = tags or {}
-                    for k, v in sampler_tags.items():
+                    for k, v in six.iteritems(sampler_tags):
                         tags[k] = v
             else:  # have debug id
                 flags = SAMPLED_FLAG | DEBUG_FLAG
@@ -165,7 +166,7 @@ class Tracer(opentracing.Tracer):
 
         if (rpc_server or not parent_id) and (flags & SAMPLED_FLAG):
             # this is a first-in-process span, and is sampled
-            for k, v in self.tags.items():
+            for k, v in six.iteritems(self.tags):
                 span.set_tag(k, v)
 
         self._emit_span_metrics(span=span, join=rpc_server)

--- a/jaeger_client/utils.py
+++ b/jaeger_client/utils.py
@@ -17,7 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-from builtins import str
+from builtins import bytes
 from builtins import range
 from builtins import object
 import fcntl
@@ -73,7 +73,7 @@ def local_ip():
     if ip.startswith('127.'):
         # Check eth0, eth1, eth2, en0, ...
         interfaces = [
-            i + str(n) for i in ('eth', 'en', 'wlan') for n in range(3)
+            i + bytes(n) for i in (b'eth', b'en', b'wlan') for n in range(3)
         ]  # :(
         for interface in interfaces:
             try:

--- a/jaeger_client/utils.py
+++ b/jaeger_client/utils.py
@@ -17,6 +17,9 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+from builtins import str
+from builtins import range
+from builtins import object
 import fcntl
 import socket
 import struct
@@ -70,7 +73,7 @@ def local_ip():
     if ip.startswith('127.'):
         # Check eth0, eth1, eth2, en0, ...
         interfaces = [
-            i + str(n) for i in ('eth', 'en', 'wlan') for n in xrange(3)
+            i + str(n) for i in ('eth', 'en', 'wlan') for n in range(3)
         ]  # :(
         for interface in interfaces:
             try:

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'thrift',
         'tornado>=4.3,<5',
         'opentracing>=1.2.2,<1.3',
+        "future",
     ],
     # Uncomment below if need to test with unreleased version of opentracing
     # dependency_links=[

--- a/tests/test_TUDPTransport.py
+++ b/tests/test_TUDPTransport.py
@@ -39,7 +39,7 @@ class TUDPTransportTests(unittest.TestCase):
         assert t.transport_sock.gettimeout() == 0
 
     def test_write(self):
-        self.t.write('hello')
+        self.t.write(b'hello')
 
     def test_isopen_when_open(self):
         assert self.t.isOpen() == True
@@ -52,4 +52,4 @@ class TUDPTransportTests(unittest.TestCase):
         self.t.close()
         with self.assertRaises(Exception):
             # Something bad should happen if we send on a closed socket..
-            self.t.write('hello')
+            self.t.write(b'hello')

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -84,8 +84,8 @@ class TestCodecs(unittest.TestCase):
         from_string = span_context_from_string
 
         tests = [
-            [(256L, 127L, None, 1), '100:7f:0:1'],
-            [(256L, 127L, 256L, 0), '100:7f:100:0'],
+            [(256, 127, None, 1), '100:7f:0:1'],
+            [(256, 127, 256, 0), '100:7f:100:0'],
         ]
         for test in tests:
             ctx = test[0]
@@ -95,13 +95,13 @@ class TestCodecs(unittest.TestCase):
             self.assertEqual(ctx_rev, ctx)
 
         ctx_rev = from_string(['100:7f:100:0'])
-        assert ctx_rev == (256L, 127L, 256L, 0), 'Array is acceptable'
+        assert ctx_rev == (256, 127, 256, 0), 'Array is acceptable'
 
         with self.assertRaises(SpanContextCorruptedException):
             from_string(['100:7f:100:0', 'garbage'])
 
         ctx_rev = from_string(u'100:7f:100:0')
-        assert ctx_rev == (256L, 127L, 256L, 0), 'Unicode is acceptable'
+        assert ctx_rev == (256, 127, 256, 0), 'Unicode is acceptable'
 
     def test_context_to_readable_headers(self):
         for url_encoding in [False, True]:
@@ -215,14 +215,14 @@ class TestCodecs(unittest.TestCase):
             'Trace-ID': 'FFFFFFFFFFFFFFFF:FFFFFFFFFFFFFFFF:FFFFFFFFFFFFFFFF:1',
         }
         context = codec.extract(headers)
-        assert context.trace_id == 0xFFFFFFFFFFFFFFFFL
-        assert context.trace_id == (1L << 64) - 1
+        assert context.trace_id == 0xFFFFFFFFFFFFFFFF
+        assert context.trace_id == (1 << 64) - 1
         assert context.trace_id > 0
-        assert context.span_id == 0xFFFFFFFFFFFFFFFFL
-        assert context.span_id == (1L << 64) - 1
+        assert context.span_id == 0xFFFFFFFFFFFFFFFF
+        assert context.span_id == (1 << 64) - 1
         assert context.span_id > 0
-        assert context.parent_id == 0xFFFFFFFFFFFFFFFFL
-        assert context.parent_id == (1L << 64) - 1
+        assert context.parent_id == 0xFFFFFFFFFFFFFFFF
+        assert context.parent_id == (1 << 64) - 1
         assert context.parent_id > 0
 
     def test_zipkin_codec_extract(self):

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -322,6 +322,6 @@ def test_debug_id():
     span = tracer.start_span('test', child_of=context)
     assert span.is_debug()
     assert span.is_sampled()
-    tags = filter(lambda t: t.key == debug_header, span.tags)
+    tags = [t for t in span.tags if t.key == debug_header]
     assert len(tags) == 1
     assert tags[0].value == 'Coraline'

--- a/tests/test_crossdock.py
+++ b/tests/test_crossdock.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import
 
+from builtins import str
 import mock
 import json
 import pytest

--- a/tests/test_local_agent_net.py
+++ b/tests/test_local_agent_net.py
@@ -1,6 +1,8 @@
+from future import standard_library
+standard_library.install_aliases()
 import pytest
 import tornado.web
-from urlparse import urlparse
+from urllib.parse import urlparse
 from jaeger_client.local_agent_net import LocalAgentSender
 from jaeger_client.config import DEFAULT_REPORTING_PORT
 

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from builtins import range
 import time
 import mock
 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2016 Uber Technologies, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -162,7 +163,7 @@ class ReporterTest(AsyncTestCase):
             if fn():
                 return
             yield tornado.gen.sleep(0.001)
-        print 'waited for condition %f' % (time.time() - start)
+        print('waited for condition %f' % (time.time() - start))
 
     @gen_test
     def test_submit_batch_size_1(self):

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -18,6 +18,8 @@ from __future__ import print_function
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+from builtins import range
+from builtins import object
 import logging
 import time
 import collections

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -20,7 +20,6 @@ from __future__ import division
 # THE SOFTWARE.
 
 from builtins import range
-from past.utils import old_div
 import time
 import math
 import mock
@@ -170,7 +169,7 @@ def test_guaranteed_throughput_probabilistic_sampler():
     sampled, tags = sampler.is_sampled(MAX_INT-10)
     assert sampled
     assert tags == get_tags('probabilistic', 0.51)
-    sampled, tags = sampler.is_sampled(MAX_INT+(old_div(MAX_INT,4)))
+    sampled, tags = sampler.is_sampled(MAX_INT+(MAX_INT/4))
     assert sampled
     assert tags == get_tags('lowerbound', 0.51)
 
@@ -201,7 +200,7 @@ def test_adaptive_sampler():
     sampled, tags = sampler.is_sampled(MAX_INT-10, "new_op")
     assert sampled
     assert tags == get_tags('probabilistic', 0.51)
-    sampled, tags = sampler.is_sampled(MAX_INT+(old_div(MAX_INT,4)), "new_op")
+    sampled, tags = sampler.is_sampled(MAX_INT+(MAX_INT/4), "new_op")
     assert sampled
     assert tags == get_tags('lowerbound', 0.51)
 
@@ -210,7 +209,7 @@ def test_adaptive_sampler():
     sampled, tags = sampler.is_sampled(MAX_INT-10, "new_op_2")
     assert sampled
     assert tags == get_tags('probabilistic', 0.51)
-    sampled, _ = sampler.is_sampled(MAX_INT+(old_div(MAX_INT,4)), "new_op_2")
+    sampled, _ = sampler.is_sampled(MAX_INT+(MAX_INT/4), "new_op_2")
     assert not sampled
     assert '%s' % sampler == 'AdaptiveSampler(0.51, 3, 2)'
 

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,3 +1,4 @@
+from __future__ import division
 # Copyright (c) 2016 Uber Technologies, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -18,6 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from builtins import range
+from past.utils import old_div
 import time
 import math
 import mock
@@ -167,7 +170,7 @@ def test_guaranteed_throughput_probabilistic_sampler():
     sampled, tags = sampler.is_sampled(MAX_INT-10)
     assert sampled
     assert tags == get_tags('probabilistic', 0.51)
-    sampled, tags = sampler.is_sampled(MAX_INT+(MAX_INT/4))
+    sampled, tags = sampler.is_sampled(MAX_INT+(old_div(MAX_INT,4)))
     assert sampled
     assert tags == get_tags('lowerbound', 0.51)
 
@@ -198,7 +201,7 @@ def test_adaptive_sampler():
     sampled, tags = sampler.is_sampled(MAX_INT-10, "new_op")
     assert sampled
     assert tags == get_tags('probabilistic', 0.51)
-    sampled, tags = sampler.is_sampled(MAX_INT+(MAX_INT/4), "new_op")
+    sampled, tags = sampler.is_sampled(MAX_INT+(old_div(MAX_INT,4)), "new_op")
     assert sampled
     assert tags == get_tags('lowerbound', 0.51)
 
@@ -207,7 +210,7 @@ def test_adaptive_sampler():
     sampled, tags = sampler.is_sampled(MAX_INT-10, "new_op_2")
     assert sampled
     assert tags == get_tags('probabilistic', 0.51)
-    sampled, _ = sampler.is_sampled(MAX_INT+(MAX_INT/4), "new_op_2")
+    sampled, _ = sampler.is_sampled(MAX_INT+(old_div(MAX_INT,4)), "new_op_2")
     assert not sampled
     assert '%s' % sampler == 'AdaptiveSampler(0.51, 3, 2)'
 

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -36,7 +36,7 @@ from jaeger_client.sampler import (
     get_rate_limit,
 )
 
-MAX_INT = 1L << 63
+MAX_INT = 1 << 63
 
 def get_tags(type, param):
     return {
@@ -61,7 +61,7 @@ def test_probabilistic_sampler_errors():
 
 def test_probabilistic_sampler():
     sampler = ProbabilisticSampler(0.5)
-    assert MAX_INT == 0x8000000000000000L
+    assert MAX_INT == 0x8000000000000000
     sampled, tags = sampler.is_sampled(MAX_INT-10)
     assert sampled
     assert tags == get_tags('probabilistic', 0.5)

--- a/tests/test_thrift.py
+++ b/tests/test_thrift.py
@@ -18,7 +18,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from cStringIO import StringIO
+from future import standard_library
+standard_library.install_aliases()
+from io import StringIO
 
 import jaeger_client.thrift_gen.zipkincore.ZipkinCollector as zipkin_collector
 import jaeger_client.thrift_gen.sampling.SamplingManager as sampling_manager

--- a/tests/test_thrift.py
+++ b/tests/test_thrift.py
@@ -20,7 +20,7 @@
 
 from future import standard_library
 standard_library.install_aliases()
-from io import StringIO
+from io import BytesIO
 
 import jaeger_client.thrift_gen.zipkincore.ZipkinCollector as zipkin_collector
 import jaeger_client.thrift_gen.sampling.SamplingManager as sampling_manager
@@ -79,7 +79,7 @@ def _marshall_span(span):
             it's one or the other (really? yes.). This will convert
             us from write-able to read-able.
             """
-            self._buffer = StringIO(self.getvalue())
+            self._buffer = BytesIO(self.getvalue())
 
     spans = thrift.make_zipkin_spans([span])
 

--- a/tests/test_thrift.py
+++ b/tests/test_thrift.py
@@ -120,8 +120,8 @@ def test_large_ids(tracer):
     trace_id = 0x97fd53dc6b437681
     serialize(trace_id)
 
-    trace_id = (1L << 64) - 1
-    assert trace_id == 0xffffffffffffffffL
+    trace_id = (1 << 64) - 1
+    assert trace_id == 0xffffffffffffffff
     serialize(trace_id)
     assert thrift.id_to_int(trace_id) == -1
 

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -20,6 +20,7 @@
 
 import mock
 import random
+import six
 
 import pytest
 import tornado.httputil
@@ -224,7 +225,7 @@ def test_tracer_tags_on_root_span(span_type, expected_tags):
                 'child', child_of=span.context,
                 tags={ext_tags.SPAN_KIND: ext_tags.SPAN_KIND_RPC_SERVER}
             )
-        for key, value in expected_tags.items():
+        for key, value in six.iteritems(expected_tags):
             found_tag = None
             for tag in span.tags:
                 if tag.key == key:

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -33,15 +33,15 @@ from jaeger_client.thrift import add_zipkin_annotations
 
 
 def log_exists(span, value):
-    return filter(lambda (x): x.value == value, span.logs) != []
+    return filter(lambda x: x.value == value, span.logs) != []
 
 
 def test_start_trace(tracer):
     assert type(tracer) is Tracer
     with mock.patch.object(random.Random, 'getrandbits') as mock_random, \
             mock.patch('time.time') as mock_timestamp:
-        mock_random.return_value = 12345L
-        mock_timestamp.return_value = 54321L
+        mock_random.return_value = 12345
+        mock_timestamp.return_value = 54321
 
         span = tracer.start_span('test')
         span.set_tag(ext_tags.SPAN_KIND, ext_tags.SPAN_KIND_RPC_SERVER)
@@ -49,10 +49,10 @@ def test_start_trace(tracer):
         assert span.tracer == tracer, "Tracer must be referenced from span"
         assert span.kind == ext_tags.SPAN_KIND_RPC_SERVER, \
             'Span must be server-side'
-        assert span.trace_id == 12345L, "Must match trace_id"
+        assert span.trace_id == 12345, "Must match trace_id"
         assert span.is_sampled(), "Must be sampled"
         assert span.parent_id is None, "Must not have parent_id (root span)"
-        assert span.start_time == 54321L, "Must match timestamp"
+        assert span.start_time == 54321, "Must match timestamp"
 
         span.finish()
         assert span.end_time is not None, "Must have end_time defined"

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -33,7 +33,7 @@ from jaeger_client.thrift import add_zipkin_annotations
 
 
 def log_exists(span, value):
-    return filter(lambda x: x.value == value, span.logs) != []
+    return [x for x in span.logs if x.value == value] != []
 
 
 def test_start_trace(tracer):
@@ -224,7 +224,7 @@ def test_tracer_tags_on_root_span(span_type, expected_tags):
                 'child', child_of=span.context,
                 tags={ext_tags.SPAN_KIND: ext_tags.SPAN_KIND_RPC_SERVER}
             )
-        for key, value in expected_tags.iteritems():
+        for key, value in expected_tags.items():
             found_tag = None
             for tag in span.tags:
                 if tag.key == key:

--- a/tests/test_tracer_benchmark.py
+++ b/tests/test_tracer_benchmark.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from builtins import range
 import time
 from opentracing import Tracer as NoopTracer
 from jaeger_client.tracer import Tracer


### PR DESCRIPTION
As per the suggestion https://github.com/uber/jaeger-client-python/pull/43#issuecomment-308895785, this PR runs `futurize` against the source with small fixes to ensure the Python 2 tests continues to pass. I thought I make this PR to get Python 3 support moving (even if it is in the smallest way possible).