### PR TITLE
Pin coverage < 4.4 to prevent spurious CI failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
             'mock==1.0.1',
             'pytest>=2.7,<3',
             'pytest-cov',
+            'coverage<4.4', # can remove after https://bitbucket.org/ned/coveragepy/issues/581/44b1-44-breaking-in-ci
             'pytest-timeout',
             'pytest-tornado',
             'pytest-benchmark[histogram]>=3.0.0rc1',


### PR DESCRIPTION
Pending a fix here: https://bitbucket.org/ned/coveragepy/issues/581/44b1-44-breaking-in-ci